### PR TITLE
Change Eigen SparseMatrix to RowMajor format in spmm and spmv benchmarks to enable omp parallelization

### DIFF
--- a/examples/benchmarks/eigen_benchmarks/eigen_spmm.cpp
+++ b/examples/benchmarks/eigen_benchmarks/eigen_spmm.cpp
@@ -12,7 +12,7 @@ int main(int argc, char *argv[]) {
         Eigen::MatrixXd::Constant(crs_mat->n_rows, n_vectors, 0.0);
 
     // Wrap your CRS data into an Eigen SparseMatrix
-    Eigen::SparseMatrix<double> eigen_mat(crs_mat->n_rows, crs_mat->n_cols);
+    Eigen::SparseMatrix<double, Eigen::RowMajor> eigen_mat(crs_mat->n_rows, crs_mat->n_cols);
     std::vector<Eigen::Triplet<double>> triplets;
     triplets.reserve(crs_mat->nnz);
 

--- a/examples/benchmarks/eigen_benchmarks/eigen_spmv.cpp
+++ b/examples/benchmarks/eigen_benchmarks/eigen_spmv.cpp
@@ -10,7 +10,7 @@ int main(int argc, char *argv[]) {
     Eigen::VectorXd eigen_y = Eigen::VectorXd::Constant(crs_mat->n_rows, 0.0);
 
     // Wrap your CRS data into an Eigen SparseMatrix
-    Eigen::SparseMatrix<double> eigen_mat(crs_mat->n_rows, crs_mat->n_cols);
+    Eigen::SparseMatrix<double, Eigen::RowMajor> eigen_mat(crs_mat->n_rows, crs_mat->n_cols);
     std::vector<Eigen::Triplet<double>> triplets;
     triplets.reserve(crs_mat->nnz);
 


### PR DESCRIPTION
sparse Eigen uses openmp only for row-major-sparse * dense vector/matrix products 