### PR TITLE
Improve benchmarking consistency with parallel LIKWID markers and Eigen tuning

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -193,8 +193,6 @@ if(USE_EIGEN)
         include(cmake/eigen.cmake)
     endif()
 
-    # Optional: Compiler flags specific to Eigen performance tuning
-    add_compile_options(-mavx2 -mno-avx512f)
 else()
     message(STATUS "Eigen support is disabled.")
 endif()

--- a/examples/benchmarks/eigen_benchmarks/CMakeLists.txt
+++ b/examples/benchmarks/eigen_benchmarks/CMakeLists.txt
@@ -25,6 +25,10 @@ foreach(src ${CPP_FILES})
 
     # Add to the list of targets
     list(APPEND eigen_benchmarks_targets ${exec_name})
+
+    target_compile_options(${exec_name} PRIVATE -mavx512f)
+    target_compile_definitions(${exec_name} PRIVATE EIGEN_VECTORIZE_AVX512)
+
 endforeach()
 
 # Export the list to parent scope

--- a/examples/benchmarks/eigen_benchmarks/eigen_spgemm.cpp
+++ b/examples/benchmarks/eigen_benchmarks/eigen_spgemm.cpp
@@ -58,9 +58,9 @@ int main(int argc, char *argv[]) {
 
     std::function<void(bool)> lambda = [bench_name, &eigen_A, &eigen_B,
                                         &eigen_C](bool warmup) {
-        IF_USE_LIKWID(if (!warmup) LIKWID_MARKER_START(bench_name.c_str());)
+        PARALLEL_LIKWID_MARKER_START(bench_name.c_str());
         eigen_C = eigen_A * eigen_B;
-        IF_USE_LIKWID(if (!warmup) LIKWID_MARKER_STOP(bench_name.c_str());)
+        PARALLEL_LIKWID_MARKER_STOP(bench_name.c_str());
     };
 
     RUN_BENCH;

--- a/examples/benchmarks/eigen_benchmarks/eigen_spmm.cpp
+++ b/examples/benchmarks/eigen_benchmarks/eigen_spmm.cpp
@@ -56,9 +56,9 @@ int main(int argc, char *argv[]) {
 
     std::function<void(bool)> lambda = [bench_name, eigen_mat, eigen_x,
                                         &eigen_y](bool warmup) {
-        IF_USE_LIKWID(if (!warmup) LIKWID_MARKER_START(bench_name.c_str());)
+        PARALLEL_LIKWID_MARKER_START(bench_name.c_str());
         eigen_y.noalias() = eigen_mat * eigen_x;
-        IF_USE_LIKWID(if (!warmup) LIKWID_MARKER_STOP(bench_name.c_str());)
+        PARALLEL_LIKWID_MARKER_STOP(bench_name.c_str());
     };
 
     RUN_BENCH;

--- a/examples/benchmarks/eigen_benchmarks/eigen_spmv.cpp
+++ b/examples/benchmarks/eigen_benchmarks/eigen_spmv.cpp
@@ -52,9 +52,9 @@ int main(int argc, char *argv[]) {
 
     std::function<void(bool)> lambda = [bench_name, eigen_mat, eigen_x,
                                         &eigen_y](bool warmup) {
-        IF_USE_LIKWID(if (!warmup) LIKWID_MARKER_START(bench_name.c_str());)
+        PARALLEL_LIKWID_MARKER_START(bench_name.c_str());
         eigen_y.noalias() = eigen_mat * eigen_x;
-        IF_USE_LIKWID(if (!warmup) LIKWID_MARKER_STOP(bench_name.c_str());)
+        PARALLEL_LIKWID_MARKER_STOP(bench_name.c_str());
     };
 
     RUN_BENCH;

--- a/examples/benchmarks/eigen_benchmarks/eigen_sptrsm.cpp
+++ b/examples/benchmarks/eigen_benchmarks/eigen_sptrsm.cpp
@@ -55,9 +55,9 @@ int main(int argc, char *argv[]) {
 
     std::function<void(bool)> lambda = [bench_name, &eigen_mat, &X,
                                         &B](bool warmup) {
-        IF_USE_LIKWID(if (!warmup) LIKWID_MARKER_START(bench_name.c_str());)
+        PARALLEL_LIKWID_MARKER_START(bench_name.c_str());
         X.noalias() = eigen_mat.triangularView<Eigen::Lower>().solve(B);
-        IF_USE_LIKWID(if (!warmup) LIKWID_MARKER_STOP(bench_name.c_str());)
+        PARALLEL_LIKWID_MARKER_STOP(bench_name.c_str());
     };
 
     RUN_BENCH;

--- a/examples/benchmarks/eigen_benchmarks/eigen_sptrsv.cpp
+++ b/examples/benchmarks/eigen_benchmarks/eigen_sptrsv.cpp
@@ -52,9 +52,9 @@ int main(int argc, char *argv[]) {
 
     std::function<void(bool)> lambda = [bench_name, &eigen_mat, &x,
                                         &b](bool warmup) {
-        IF_USE_LIKWID(if (!warmup) LIKWID_MARKER_START(bench_name.c_str());)
+        PARALLEL_LIKWID_MARKER_START(bench_name.c_str());
         x.noalias() = eigen_mat.triangularView<Eigen::Lower>().solve(b);
-        IF_USE_LIKWID(if (!warmup) LIKWID_MARKER_STOP(bench_name.c_str());)
+        PARALLEL_LIKWID_MARKER_STOP(bench_name.c_str());
     };
 
     RUN_BENCH;


### PR DESCRIPTION
Replace LIKWID marker macros with parallel versions for better performance measurement and adjust compiler flags for consistent AVX512 settings in Eigen benchmarks. 

solved the #2 issue